### PR TITLE
feat(lib): ssr-detecting icon base

### DIFF
--- a/src/lib/ClientBase.tsx
+++ b/src/lib/ClientBase.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { forwardRef, useContext } from "react";
+import { IconContext } from "./context";
+import { IconBaseProps } from "./types";
+
+const ClientBase = forwardRef<SVGSVGElement, IconBaseProps>((props, ref) => {
+  const {
+    alt,
+    color,
+    size,
+    weight,
+    mirrored,
+    children,
+    weights,
+    ...restProps
+  } = props;
+
+  const {
+    color: contextColor = "currentColor",
+    size: contextSize,
+    weight: contextWeight = "regular",
+    mirrored: contextMirrored = false,
+    ...restContext
+  } = useContext(IconContext);
+
+  return (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size ?? contextSize}
+      height={size ?? contextSize}
+      fill={color ?? contextColor}
+      viewBox="0 0 256 256"
+      transform={mirrored || contextMirrored ? "scale(-1, 1)" : undefined}
+      {...restContext}
+      {...restProps}
+    >
+      {!!alt && <title>{alt}</title>}
+      {children}
+      {weights.get(weight ?? contextWeight)}
+    </svg>
+  );
+});
+
+export default ClientBase;

--- a/src/lib/IconBase.tsx
+++ b/src/lib/IconBase.tsx
@@ -1,50 +1,13 @@
-"use client";
+import { forwardRef } from "react";
 
-import { forwardRef, useContext, ReactElement } from "react";
-import { IconContext } from "./context";
-import { IconProps, IconWeight } from "./types";
-
-interface IconBaseProps extends IconProps {
-  weights: Map<IconWeight, ReactElement>;
-}
+import { IconBaseProps } from "./types";
+import { isClient } from "./utils";
+import ClientBase from "./ClientBase";
+import ServerBase from "./ServerBase";
 
 const IconBase = forwardRef<SVGSVGElement, IconBaseProps>((props, ref) => {
-  const {
-    alt,
-    color,
-    size,
-    weight,
-    mirrored,
-    children,
-    weights,
-    ...restProps
-  } = props;
-
-  const {
-    color: contextColor = "currentColor",
-    size: contextSize,
-    weight: contextWeight = "regular",
-    mirrored: contextMirrored = false,
-    ...restContext
-  } = useContext(IconContext);
-
-  return (
-    <svg
-      ref={ref}
-      xmlns="http://www.w3.org/2000/svg"
-      width={size ?? contextSize}
-      height={size ?? contextSize}
-      fill={color ?? contextColor}
-      viewBox="0 0 256 256"
-      transform={mirrored || contextMirrored ? "scale(-1, 1)" : undefined}
-      {...restContext}
-      {...restProps}
-    >
-      {!!alt && <title>{alt}</title>}
-      {children}
-      {weights.get(weight ?? contextWeight)}
-    </svg>
-  );
+  const Base = isClient() ? ClientBase : ServerBase;
+  return <Base ref={ref} {...props} />;
 });
 
 IconBase.displayName = "IconBase";

--- a/src/lib/ServerBase.tsx
+++ b/src/lib/ServerBase.tsx
@@ -1,0 +1,36 @@
+import { forwardRef } from "react";
+import { IconBaseProps } from "./types";
+
+const IconBase = forwardRef<SVGSVGElement, IconBaseProps>((props, ref) => {
+  const {
+    alt,
+    color = "currentColor",
+    size = "1em",
+    weight = "regular",
+    mirrored,
+    children,
+    weights,
+    ...restProps
+  } = props;
+
+  return (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      fill={color}
+      viewBox="0 0 256 256"
+      transform={mirrored ? "scale(-1, 1)" : undefined}
+      {...restProps}
+    >
+      {!!alt && <title>{alt}</title>}
+      {children}
+      {weights.get(weight)}
+    </svg>
+  );
+});
+
+IconBase.displayName = "IconBase";
+
+export default IconBase;

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,3 +1,4 @@
+"use client";
 import { createContext } from "react";
 import type { IconProps } from "./types";
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,3 @@
 export { IconContext } from "./context";
-export type { Icon, IconProps, IconWeight } from "./types";
+export type { Icon, IconProps, IconWeight, IconBaseProps } from "./types";
 export { default as IconBase } from "./IconBase";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef } from "react";
+import { ComponentPropsWithRef, ReactElement } from "react";
 
 export type IconWeight =
   | "thin"
@@ -17,3 +17,7 @@ export interface IconProps extends ComponentPropsWithRef<"svg"> {
 }
 
 export type Icon = React.ForwardRefExoticComponent<IconProps>;
+
+export interface IconBaseProps extends IconProps {
+  weights: Map<IconWeight, ReactElement>;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,7 @@
+export function isClient() {
+  return !!(
+    typeof window !== "undefined" &&
+    window.document &&
+    window.document.createElement
+  );
+}


### PR DESCRIPTION
This patch enables full support of RSC, allowing icons to be used in Server Components by detecting if we are SSR, and rendering a base component that does not rely on `useContext` if so.

TODO:
- [ ] Figure our if there are inherent gotchas with shipping non-isomorphic components like this
- [ ] Asses any performance cost (shouldn't be noticeable, but let's see)
- [ ] Asses any performance gain over simply marking all icons with `"use client"`
- [ ] Configure Vite build to inject `banner` where appropriate