### PR TITLE
Attempt to fix server-side build by allowing module usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@phosphor-icons/react",
   "version": "2.0.9",
+  "type": "module",
   "description": "A clean and friendly icon family for React",
   "author": {
     "name": "Tobias Fried",


### PR DESCRIPTION
Myself and others have run into this issue with the new (non-legacy) version of `@phosphor-icons/react`. I'm not really sure what the underlying difference is between this version and the older `phosphor-react` package, but when I made this change—suddenly my builds started working again.

Reference:
https://github.com/phosphor-icons/react/issues/55