### PR TITLE
Default SSRBase size to 1em, fixes #69

### DIFF
--- a/src/lib/SSRBase.tsx
+++ b/src/lib/SSRBase.tsx
@@ -9,7 +9,7 @@ const SSRBase = forwardRef<SVGSVGElement, IconBaseProps>((props, ref) => {
   const {
     alt,
     color = "currentColor",
-    size,
+    size = "1em",
     weight = "regular",
     mirrored = false,
     children,


### PR DESCRIPTION
This is to have sensible defaults and to align with CSR defaults

Fixes #69