### PR TITLE
Add self export of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
       "require": "./dist/index.cjs",
       "types": "./dist/ssr/*.d.ts"
     },
+    "./package.json": {
+      "default": "./package.json"
+    },
     "./*": {
       "import": "./dist/csr/*.mjs",
       "require": "./dist/index.cjs",


### PR DESCRIPTION
Because of the catchall export (`"./*"`) packages like [resolve-from](https://www.npmjs.com/package/resolve-from) are unable to load the package.json.

Attempting to do so, they'll get redirected to the `index.*` packages.
This is affecting using this package in things like storybook where we get the warning

```
unable to find package.json for @phosphor-icons/react
```