### PR TITLE
build: fix `IconProps` type definition

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef } from "react";
+import { ComponentPropsWithoutRef, RefAttributes } from "react";
 
 export type IconWeight =
   | "thin"
@@ -8,7 +8,7 @@ export type IconWeight =
   | "fill"
   | "duotone";
 
-export interface IconProps extends ComponentPropsWithRef<"svg"> {
+export interface IconProps extends ComponentPropsWithoutRef<"svg">, RefAttributes<SVGSVGElement> {
   alt?: string;
   color?: string;
   size?: string | number;


### PR DESCRIPTION
to be compatible with the latest `@types/react`
To reproduce the issue create custom icon in a project that uses `@types/react` 18.3.3 OR update `@types/react` to 18.3.3 in this project. 
Fixes: https://github.com/phosphor-icons/react/issues/98
cc: @rektdeckard 