### PR TITLE
Update Readme for Import Performance Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To avoid transpiling all modules, import individual icons from their specific fi
 import { BellSimple } from "@phosphor-icons/react/dist/icons/BellSimple";
 ```
 
-**Alternatively,**
+#### Next.js Specific Optimizations
 
 If you're using Next.js 13+, consider using [optimizePackageImports](https://nextjs.org/docs/app/api-reference/config/next-config-js/optimizePackageImports) in your next.config.js to have Next.js only load the modules that you are actually using. With this approach, you can use `@phosphor-icons/react` directly without causing Next.js to compile all its modules:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const App = () => {
 
 ### Import Performance Optimization
 
-When importing icons during development in a React environment straight from the main module: `@phosphor-icons/react`, the React environment compiles all the 9k+ modules exported from `@phosphor-icons/react`. This greatly increases the compliation time. To avoid compiling all modules, import individual icons from their specific icon files:
+When importing icons during development within a React environment directly from the main module: `@phosphor-icons/react`, the React environment compiles all the 9k+ modules exported from `@phosphor-icons/react`. This greatly increases the compliation time. To avoid compiling all modules, import individual icons from their specific icon files:
 
 ```tsx
 import { BellSimple } from "@phosphor-icons/react/dist/icons/BellSimple";

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you're using Next.js 13+, consider using [optimizePackageImports](https://nex
 ```tsx
 module.exports = {
   experimental: {
-    optimizePackageImports: ['@phosphor-icons/react'],
+    optimizePackageImports: ["@phosphor-icons/react"],
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When importing icons during development within a React environment directly from
 import { BellSimple } from "@phosphor-icons/react/dist/icons/BellSimple";
 ```
 
-Alternatively,
+**Alternatively,**
 
 If you're using Next.js 13+, consider using [optimizePackageImports](https://nextjs.org/docs/app/api-reference/config/next-config-js/optimizePackageImports) in your next.config.js to have Next.js only load the modules that you are actually using. With this approach, you can use `@phosphor-icons/react` directly without causing Next.js to compile all its modules:
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ const App = () => {
 };
 ```
 
+### Import Performance Optimization
+
+When importing icons during development in a React environment straight from the main module: `@phosphor-icons/react`, the React environment compiles all the 9k+ modules exported from `@phosphor-icons/react`. This greatly increases the compliation time. To avoid compiling all modules, import individual icons from their specific icon files:
+
+```tsx
+import { BellSimple } from "@phosphor-icons/react/dist/icons/BellSimple";
+```
+
+Alternatively,
+
+If you're using Next.js 13+, consider using [optimizePackageImports](https://nextjs.org/docs/app/api-reference/config/next-config-js/optimizePackageImports) in your next.config.js to have Next.js only load the modules that you are actually using. With this approach, you can use `@phosphor-icons/react` directly without causing Next.js to compile all its modules:
+
+```tsx
+module.exports = {
+  experimental: {
+    optimizePackageImports: ['@phosphor-icons/react'],
+  },
+}
+```
+
 ### React Server Components and SSR
 
 When using Phosphor Icons in an SSR environment, within a React Server Component, or in any environment that does not permit the use of the Context API ([Next.js](https://nextjs.org/) Server Component, for example), import icons from the `/dist/ssr` submodule:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ const App = () => {
 
 ### Import Performance Optimization
 
-When importing icons during development within a React environment directly from the main module: `@phosphor-icons/react`, the React environment compiles all the 9k+ modules exported from `@phosphor-icons/react`. This greatly increases the compliation time. To avoid compiling all modules, import individual icons from their specific icon files:
+When importing icons during development directly from the main module `@phosphor-icons/react`, some bundlers may eagerly transpile all 9,000+ modules exported by the package. This behavior can drastically increase compilation time.
+To avoid transpiling all modules, import individual icons from their specific file paths instead:
 
 ```tsx
 import { BellSimple } from "@phosphor-icons/react/dist/icons/BellSimple";


### PR DESCRIPTION
This PR adds documentation about optimizing import performance when using phosphor-icons in React applications. It addresses the issue where importing from the main module during development causes the React environment to compile all 9k+ modules, significantly increasing compilation time.

It recommends the solution of importing icons directly from their specific icon files. For Nextjs users, it recommends using [optimizePackageImports](https://nextjs.org/docs/app/api-reference/config/next-config-js/optimizePackageImports) to have Next.js automatically only compile modules being used.

Thanks to @rektdeckard for suggesting the Next.js optimization approach.

Closes phosphor-icons/homepage#770

P.S, this is my first actual pr... ever :)